### PR TITLE
acts_as_markdown_list

### DIFF
--- a/app/controllers/components_controller.rb
+++ b/app/controllers/components_controller.rb
@@ -18,13 +18,12 @@ class ComponentsController < ApplicationController
   def update
     component = Component.find(params[:id])
     component.update_attributes(component_params)
-    component.create_or_update_list
+    Relationship.touch_all_parents_of(component)
     redirect_to action: "show", id: component.id
   end
 
   def create
     component = Component.create(component_params)
-    component.create_or_update_list
     redirect_to action: "show", id: component.id
   end
 

--- a/app/models/acts_as_markdown_list.rb
+++ b/app/models/acts_as_markdown_list.rb
@@ -1,9 +1,13 @@
 module ActsAsMarkdownList
   module ActsAsMethods
 
-    def acts_as_markdown_list(options = {})
+    def acts_as_markdown_list(markdown_field)
       has_many :relationships, as: :relatable, dependent: :destroy
       after_save :create_relationships
+
+      define_method(:markdown) do
+        send(markdown_field)
+      end
 
       define_method(:elements) do
         relationships.map do |rel|
@@ -16,7 +20,7 @@ module ActsAsMarkdownList
       end
 
       define_method(:create_relationships) do
-        delete_and_save_relationships if content_as_markdown_changed?
+        delete_and_save_relationships if send("#{markdown_field}_changed?")
       end
 
       define_method(:delete_and_save_relationships) do
@@ -27,7 +31,7 @@ module ActsAsMarkdownList
       end
 
       define_method(:relationships_from_markdown) do
-        CustomMarkdown.relationships_from_markdown(self, content_as_markdown, :in_list_content)
+        CustomMarkdown.relationships_from_markdown(self, markdown, :in_list_content)
       end
 
     end

--- a/app/models/acts_as_markdown_list.rb
+++ b/app/models/acts_as_markdown_list.rb
@@ -1,0 +1,7 @@
+module ActsAsMarkdownList
+  module ActsAsMethods
+    def acts_as_markdown_list(options = {})
+      has_many :relationships, as: :relatable, dependent: :destroy
+    end
+  end
+end

--- a/app/models/acts_as_markdown_list.rb
+++ b/app/models/acts_as_markdown_list.rb
@@ -1,15 +1,15 @@
 module ActsAsMarkdownList
   module ActsAsMethods
 
-    def acts_as_markdown_list(markdown_field)
+    def acts_as_markdown_list(markdown_field, options = {})
       has_many :relationships, as: :relatable, dependent: :destroy
       after_save :create_relationships
 
       define_method(:markdown) do
-        send(markdown_field)
+        send(markdown_field) || options[:default]
       end
 
-      define_method(:elements) do
+      define_method(:list_elements) do
         relationships.map do |rel|
           rel.expand || rel.child
         end.flatten.uniq.keep_if { |element| element.try(:published?) }

--- a/app/models/acts_as_markdown_list.rb
+++ b/app/models/acts_as_markdown_list.rb
@@ -1,7 +1,35 @@
 module ActsAsMarkdownList
   module ActsAsMethods
+
     def acts_as_markdown_list(options = {})
       has_many :relationships, as: :relatable, dependent: :destroy
+      after_save :create_relationships
+
+      define_method(:elements) do
+        relationships.map do |rel|
+          rel.expand || rel.child
+        end.flatten.uniq.keep_if { |element| element.try(:published?) }
+      end
+
+      define_method(:recipes) do
+        relationships.select{ |rel| rel.child_type == "Recipe" }.map(&:child).keep_if { |element| element.published? }
+      end
+
+      define_method(:create_relationships) do
+        delete_and_save_relationships if content_as_markdown_changed?
+      end
+
+      define_method(:delete_and_save_relationships) do
+        if relationships_from_markdown.present? && self.id
+          relationships.delete_all
+          Relationship.create(relationships_from_markdown)
+        end
+      end
+
+      define_method(:relationships_from_markdown) do
+        CustomMarkdown.relationships_from_markdown(self, content_as_markdown, :in_list_content)
+      end
+
     end
   end
 end

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -86,7 +86,7 @@ class Component < ActiveRecord::Base
   end
 
   def default_list_markdown
-    ":[#{name} 100]"
+    name.present? ? ":[#{name} 100]" : ""
   end
 
   def link

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -2,7 +2,11 @@ require 'recipe.rb'
 
 class Component < ActiveRecord::Base
   extend FriendlyId
+  extend ActsAsMarkdownList::ActsAsMethods
+
   friendly_id :custom_name, use: :slugged
+
+  acts_as_markdown_list :list_as_markdown, :default => ":[#{name} 100]"
 
   serialize :recipe_ids, Array
   has_many :pseudonyms, as: :pseudonymable, dependent: :destroy
@@ -62,10 +66,6 @@ class Component < ActiveRecord::Base
     nick.present? ? nick : name
   end
 
-  def list_for_textarea
-    list_as_markdown ? list_as_markdown : ":[#{name} 100]"
-  end
-
   def pseudonyms_as_array
     pseudonyms_as_markdown.split(",").map(&:strip).map(&:downcase)
   end
@@ -81,17 +81,12 @@ class Component < ActiveRecord::Base
     end
   end
 
-  def create_or_update_list
-    if list
-      List.find(list).update_attributes(content_as_markdown: list_for_textarea, component: id)
-    else
-      list_element = List.create(content_as_markdown: list_for_textarea, name: name, component: id)
-      update_attribute(:list, list_element.id)
-    end
+  def list_for_textarea_with_default
+    list_as_markdown || default_list_markdown
   end
 
-  def list_elements
-    recipes
+  def default_list_markdown
+    ":[#{name} 100]"
   end
 
   def link

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -9,7 +9,7 @@ class List < ActiveRecord::Base
 
   friendly_id :custom_name, use: :slugged
 
-  acts_as_markdown_list
+  acts_as_markdown_list :content_as_markdown
 
   def url
     "/list/#{slug}"

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -1,7 +1,6 @@
 require 'recipe.rb'
 require 'component.rb'
 require 'custom_markdown.rb'
-require 'acts_as_markdown_list.rb'
 
 class List < ActiveRecord::Base
   extend FriendlyId

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -11,6 +11,10 @@ class List < ActiveRecord::Base
 
   acts_as_markdown_list :content_as_markdown
 
+  def elements
+    list_elements
+  end
+
   def url
     "/list/#{slug}"
   end

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -9,32 +9,7 @@ class List < ActiveRecord::Base
 
   friendly_id :custom_name, use: :slugged
 
-  after_save :create_relationships
-
-  serialize :element_ids, Array
-
   acts_as_markdown_list
-
-  def elements
-    relationships.map do |rel|
-      rel.expand || rel.child
-    end.flatten.uniq.keep_if { |element| element.try(:published?) }
-  end
-
-  def create_relationships
-    delete_and_save_relationships if content_as_markdown_changed?
-  end
-
-  def delete_and_save_relationships
-    if relationships_from_markdown.present? && self.id
-      relationships.delete_all
-      Relationship.create(relationships_from_markdown)
-    end
-  end
-
-  def relationships_from_markdown
-    CustomMarkdown.relationships_from_markdown(self, content_as_markdown, :in_list_content)
-  end
 
   def url
     "/list/#{slug}"
@@ -66,10 +41,6 @@ class List < ActiveRecord::Base
 
   def count_for_display
     "#{elements.count} cocktails"
-  end
-
-  def recipes
-    relationships.select{ |rel| rel.child_type == "Recipe" }.map(&:child).keep_if { |element| element.published? }
   end
 
   def link

--- a/app/views/components/_form.html.erb
+++ b/app/views/components/_form.html.erb
@@ -7,7 +7,7 @@
   </div>
   <div class="form_block secondary">
     <%= f.label "component recipes" %>
-    <%= f.text_area :list_as_markdown, :value => @component.list_for_textarea, :class => "autocomplete recipes components lists" %>
+    <%= f.text_area :list_as_markdown, :value => @component.list_for_textarea_with_default, :class => "autocomplete recipes components lists" %>
     <%= render "shared/image_options", :element => @component, :f => f %><br/>
     <label>Never make me tall!</label>
     <%= f.check_box :never_make_me_tall, :value => default_text(:never_make_me_tall) %></br>

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,7 +5,7 @@
 #   gem 'sqlite3'
 development:
   adapter: postgresql
-  database: tuxedo_2
+  database: tuxedo
   host: localhost
   encoding: unicode
 


### PR DESCRIPTION
instead of creating a list and associating it with various elements, let's abstract the `markdown_list` functionality into a plugin, and pass the text field to it.