### PR TITLE
Add image for Apple touch icon

### DIFF
--- a/app/views/shared/_meta_tags.html.erb
+++ b/app/views/shared/_meta_tags.html.erb
@@ -5,6 +5,7 @@
   <meta property="og:title" content="<%= site_title %>" />
   <meta property="og:image" content="<%= meta_image %>" />
   <meta property="og:description" content="<%= meta_description %>" />
+  <link rel="apple-touch-icon" sizes="180x180" href="https://i.imgur.com/7coAF7c.png">
   <meta name="p:domain_verify" content="99aa7869478e426be39e0e97e08c8797"/>
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@tuxno2">


### PR DESCRIPTION
Currently, if you save Tuxedo No. 2 as a Safari shortcut on iOS, you get a funky lil image of the website (4th row):

![IMG_5800](https://user-images.githubusercontent.com/1305667/62237047-46783b00-b39e-11e9-96fa-627f6277dac0.PNG)

This branch adds a small `apple-touch-icon` that will show instead:

![sherry_180x](https://user-images.githubusercontent.com/1305667/62237526-2301c000-b39f-11e9-8c31-f5f445be6bbb.png)

It's [hosted on Imgur](https://imgur.com/a/5AZI4FG), which is kinda 'dumb', but it works. And maybe it's not the perfect image, but 'worse is better'!

Also, I didn't test this locally, because I'm too lazy to try to get this app up and running without directions. But I bet it works!